### PR TITLE
feat: Game flow clarity + wire seed inventory (#241, #242)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
     new EncyclopediaScene(encyclopediaSystem),
     new AchievementsScene(achievementSystem),
     new SeedSelectionScene(seedSelectionSystem, encyclopediaSystem, dailyChallengeSystem),
-    new GardenScene(saveManager)
+    new GardenScene(saveManager, seedSelectionSystem)
   );
 
   // Boot the first scene

--- a/src/scenes/GardenScene.ts
+++ b/src/scenes/GardenScene.ts
@@ -21,8 +21,9 @@ import { AnimationSystem, Easing } from '../systems/AnimationSystem';
 import { ParticleSystem } from '../systems/ParticleSystem';
 import { AchievementSystem } from '../systems/AchievementSystem';
 import { PlantRenderer } from '../systems/PlantRenderer';
+import { SeedSelectionSystem } from '../systems/SeedSelectionSystem';
 import { ToolBar, Encyclopedia, DiscoveryPopup, HazardUI, HazardWarning, HazardTooltip, HUD, SeedInventory, PlantInfoPanel, DaySummary, PauseMenu, ScoreSummary, SaveIndicator, SynergyTooltip, TutorialOverlay, AchievementNotification, AchievementGallery } from '../ui';
-import type { DaySummaryData, PauseMenuCallbacks, HazardWarningData } from '../ui';
+import type { DaySummaryData, PauseMenuCallbacks, HazardWarningData, GamePhase } from '../ui';
 import { InputManager } from '../core/InputManager';
 import { TouchController } from '../core/TouchController';
 import { GAME, TOUCH, SCENES } from '../config';
@@ -100,6 +101,9 @@ export class GardenScene implements Scene {
   
   // TLDR: Structure placement state
   private structurePlacementMode: StructureType | null = null;
+
+  // TLDR: SeedSelectionSystem for wiring actual run seed pool (#242)
+  private seedSelectionSystem: SeedSelectionSystem;
   
   // TLDR: Season length (may be extended by Greenhouse)
   private maxSeasonDays = 12;
@@ -143,8 +147,9 @@ export class GardenScene implements Scene {
   private orientationHint: Container | null = null;
   private boundOnResize!: () => void;
 
-  constructor(saveManager: SaveManager) {
+  constructor(saveManager: SaveManager, seedSelectionSystem: SeedSelectionSystem) {
     this.saveManager = saveManager;
+    this.seedSelectionSystem = seedSelectionSystem;
   }
 
   async init(ctx: SceneContext): Promise<void> {
@@ -388,6 +393,12 @@ export class GardenScene implements Scene {
     this.seedInventory = new SeedInventory();
     this.seedInventory.setPosition(10, 0);
     this.container.addChild(this.seedInventory.getContainer());
+
+    // TLDR: Wire actual run seed pool from SeedSelectionSystem (#242)
+    const currentPool = this.seedSelectionSystem.getCurrentPool();
+    if (currentPool && currentPool.seeds.length > 0) {
+      this.seedInventory.setAvailableSeeds(currentPool.seeds);
+    }
     
     // Initialize Plant Info Panel (tooltip)
     this.plantInfoPanel = new PlantInfoPanel();
@@ -923,7 +934,65 @@ export class GardenScene implements Scene {
     // TLDR: Apply frost damage from WeatherSystem
     this.weatherSystem.applyFrostDamage(activePlants);
 
+    // TLDR: Show brief day advance summary (#241)
+    this.showDayAdvanceSummary(day);
+
     this.updateStatusText();
+  }
+
+  /**
+   * TLDR: Determine current game phase based on game state (#241)
+   */
+  private determineGamePhase(): GamePhase {
+    const actions = this.player.getActionsRemaining();
+    const activePlants = Array.from(this.plants.values()).filter(p => p.active);
+    const maturePlants = activePlants.filter(p => p.getState().growthStage === GrowthStage.MATURE);
+
+    if (actions === 0) {
+      return 'day_end';
+    }
+    if (maturePlants.length > 0) {
+      return 'harvest';
+    }
+    if (activePlants.length > 0) {
+      return 'tending';
+    }
+    return 'planting';
+  }
+
+  /**
+   * TLDR: Get contextual hint based on current phase and actions (#241)
+   */
+  private getContextualHint(phase: GamePhase, actions: number): string {
+    if (actions === 0) {
+      return 'No actions left — day will advance soon';
+    }
+    switch (phase) {
+      case 'planting':
+        return 'Tap an empty tile to plant a seed';
+      case 'tending':
+        return 'Water your plants! Select the watering can tool';
+      case 'harvest':
+        return 'Harvest mature plants by tapping them!';
+      case 'day_end':
+        return '';
+    }
+  }
+
+  /**
+   * TLDR: Show brief day advance info message (#241)
+   */
+  private showDayAdvanceSummary(day: number): void {
+    const activePlants = Array.from(this.plants.values()).filter(p => p.active);
+    const maturePlants = activePlants.filter(p => p.getState().growthStage === GrowthStage.MATURE);
+    const parts: string[] = [`☀️ Day ${day} begins!`];
+    if (activePlants.length > 0) {
+      parts.push(`${activePlants.length} plant${activePlants.length > 1 ? 's' : ''} growing`);
+    }
+    if (maturePlants.length > 0) {
+      parts.push(`${maturePlants.length} ready to harvest`);
+    }
+    this.showActionMessage(parts.join(' • '));
   }
 
   private updateStatusText(): void {
@@ -1165,6 +1234,12 @@ export class GardenScene implements Scene {
       this.grid.config.cols,
       this.gridSystem.getStructures().length,
     );
+
+    // TLDR: Phase tracking and contextual hints (#241)
+    const phase = this.determineGamePhase();
+    this.hud.setPhase(phase);
+    this.hud.setHint(this.getContextualHint(phase, actions));
+    this.hud.updatePhaseTransition(delta);
 
     // Check for season end (maxSeasonDays reached)
     if (day >= this.maxSeasonDays && !this.daySummary.isVisible() && !this.scoreSummary.isVisible()) {

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -1,6 +1,18 @@
 import { Container, Graphics, Text } from 'pixi.js';
 import { Season, SEASON_CONFIG } from '../config/seasons';
 
+/** Game phase for the phase indicator */
+export type GamePhase = 'planting' | 'tending' | 'harvest' | 'day_end';
+
+const PHASE_CONFIG: Record<GamePhase, { emoji: string; label: string; color: string }> = {
+  planting:  { emoji: '🌱', label: 'Planting',  color: '#66bb6a' },
+  tending:   { emoji: '💧', label: 'Tending',   color: '#42a5f5' },
+  harvest:   { emoji: '🌾', label: 'Harvest',   color: '#ffd700' },
+  day_end:   { emoji: '🌙', label: 'Day End',   color: '#b39ddb' },
+};
+
+const PHASE_ORDER: GamePhase[] = ['planting', 'tending', 'harvest', 'day_end'];
+
 /**
  * HUD displays game status information at the top of the screen:
  * - Day counter (Day X / 12) with circular progress
@@ -8,6 +20,8 @@ import { Season, SEASON_CONFIG } from '../config/seasons';
  * - Day progress bar (time within current day)
  * - Actions remaining
  * - Next unlock progress indicator
+ * - Phase indicator (Planting → Tending → Harvest → Day End)
+ * - Contextual "what to do" hints
  */
 export class HUD {
   private container: Container;
@@ -24,6 +38,14 @@ export class HUD {
   private lastActionPointsText: Text;
   private weatherWarningText: Text;
   private gridInfoText: Text;
+  private phaseContainer!: Container;
+  private phaseLabels: Text[] = [];
+  private phaseArrows: Text[] = [];
+  private phaseBg!: Graphics;
+  private currentPhase: GamePhase = 'planting';
+  private hintText!: Text;
+  private hintBg!: Graphics;
+  private phaseTransitionAlpha = 0;
 
   constructor() {
     this.container = new Container();
@@ -191,6 +213,79 @@ export class HUD {
     this.gridInfoText.y = 112;
     this.gridInfoText.visible = false;
     this.container.addChild(this.gridInfoText);
+
+    // Phase indicator bar (below main HUD panel)
+    this.phaseContainer = new Container();
+    this.phaseContainer.y = 140;
+
+    this.phaseBg = new Graphics();
+    this.phaseBg.roundRect(0, 0, 600, 32, 6);
+    this.phaseBg.fill({ color: 0x1a1a1a, alpha: 0.85 });
+    this.phaseBg.stroke({ color: 0x3a3a3a, width: 1 });
+    this.phaseContainer.addChild(this.phaseBg);
+
+    let phaseX = 16;
+    for (let i = 0; i < PHASE_ORDER.length; i++) {
+      const phase = PHASE_ORDER[i];
+      const cfg = PHASE_CONFIG[phase];
+      const label = new Text({
+        text: `${cfg.emoji} ${cfg.label}`,
+        style: {
+          fontFamily: 'Arial',
+          fontSize: 13,
+          fill: '#666666',
+          fontWeight: 'normal',
+        },
+      });
+      label.x = phaseX;
+      label.y = 7;
+      this.phaseContainer.addChild(label);
+      this.phaseLabels.push(label);
+      phaseX += label.width + 8;
+
+      if (i < PHASE_ORDER.length - 1) {
+        const arrow = new Text({
+          text: '→',
+          style: {
+            fontFamily: 'Arial',
+            fontSize: 13,
+            fill: '#444444',
+          },
+        });
+        arrow.x = phaseX;
+        arrow.y = 7;
+        this.phaseContainer.addChild(arrow);
+        this.phaseArrows.push(arrow);
+        phaseX += arrow.width + 8;
+      }
+    }
+    this.container.addChild(this.phaseContainer);
+
+    // Contextual hint (below phase bar)
+    this.hintBg = new Graphics();
+    this.hintBg.roundRect(0, 0, 360, 28, 6);
+    this.hintBg.fill({ color: 0x2e7d32, alpha: 0.85 });
+    this.hintBg.x = 120;
+    this.hintBg.y = 176;
+    this.hintBg.visible = false;
+    this.container.addChild(this.hintBg);
+
+    this.hintText = new Text({
+      text: '',
+      style: {
+        fontFamily: 'Arial',
+        fontSize: 12,
+        fill: '#e8f5e9',
+        fontWeight: 'bold',
+        align: 'center',
+      },
+    });
+    this.hintText.x = 130;
+    this.hintText.y = 182;
+    this.hintText.visible = false;
+    this.container.addChild(this.hintText);
+
+    this.highlightPhase('planting');
   }
 
   /**
@@ -351,6 +446,64 @@ export class HUD {
     }
     this.gridInfoText.text = parts.join('  ');
     this.gridInfoText.visible = true;
+  }
+
+  /** Highlight the current game phase; others are dimmed */
+  setPhase(phase: GamePhase): void {
+    if (phase === this.currentPhase) return;
+    this.currentPhase = phase;
+    this.highlightPhase(phase);
+    this.phaseTransitionAlpha = 1.0;
+  }
+
+  private highlightPhase(phase: GamePhase): void {
+    const activeIndex = PHASE_ORDER.indexOf(phase);
+    for (let i = 0; i < this.phaseLabels.length; i++) {
+      const cfg = PHASE_CONFIG[PHASE_ORDER[i]];
+      const isActive = i === activeIndex;
+      this.phaseLabels[i].style.fill = isActive ? cfg.color : '#555555';
+      this.phaseLabels[i].style.fontWeight = isActive ? 'bold' : 'normal';
+      this.phaseLabels[i].style.fontSize = isActive ? 14 : 13;
+    }
+    for (let i = 0; i < this.phaseArrows.length; i++) {
+      this.phaseArrows[i].style.fill = i < activeIndex ? '#888888' : '#444444';
+    }
+  }
+
+  getPhase(): GamePhase {
+    return this.currentPhase;
+  }
+
+  /** Show a contextual hint. Pass empty string to hide. */
+  setHint(hint: string): void {
+    if (hint) {
+      this.hintText.text = `💡 ${hint}`;
+      this.hintText.visible = true;
+      this.hintBg.visible = true;
+    } else {
+      this.hintText.visible = false;
+      this.hintBg.visible = false;
+    }
+  }
+
+  /** Animate phase transition flash (call each frame) */
+  updatePhaseTransition(delta: number): void {
+    if (this.phaseTransitionAlpha > 0) {
+      this.phaseTransitionAlpha -= delta * 2;
+      if (this.phaseTransitionAlpha <= 0) {
+        this.phaseTransitionAlpha = 0;
+      }
+      this.phaseBg.clear();
+      this.phaseBg.roundRect(0, 0, 600, 32, 6);
+      this.phaseBg.fill({ color: 0x1a1a1a, alpha: 0.85 });
+      if (this.phaseTransitionAlpha > 0) {
+        const cfg = PHASE_CONFIG[this.currentPhase];
+        const flashColor = parseInt(cfg.color.replace('#', ''), 16);
+        this.phaseBg.stroke({ color: flashColor, width: 2, alpha: this.phaseTransitionAlpha });
+      } else {
+        this.phaseBg.stroke({ color: 0x3a3a3a, width: 1 });
+      }
+    }
   }
 
   getContainer(): Container {

--- a/src/ui/SeedInventory.ts
+++ b/src/ui/SeedInventory.ts
@@ -1,5 +1,4 @@
 import { Container, Graphics, Text } from 'pixi.js';
-import { ALL_PLANTS } from '../config/plants';
 import { PlantConfig } from '../entities/Plant';
 
 const RARITY_COLORS = {
@@ -82,8 +81,8 @@ export class SeedInventory {
     this.cardsContainer.y = 90;
     this.container.addChild(this.cardsContainer);
 
-    // Initialize with starter seeds (common plants)
-    this.setAvailableSeeds(ALL_PLANTS.filter(p => p.rarity === 'common'));
+    // Seeds are set externally via setAvailableSeeds() from GardenScene
+    // using the actual run pool from SeedSelectionSystem
   }
 
   /**

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -9,6 +9,7 @@ export type { HazardWarningData } from './HazardWarning';
 export { HazardTooltip } from './HazardTooltip';
 export type { HazardTooltipData } from './HazardTooltip';
 export { HUD } from './HUD';
+export type { GamePhase } from './HUD';
 export { SeedInventory } from './SeedInventory';
 export { PlantInfoPanel } from './PlantInfoPanel';
 export { DaySummary } from './DaySummary';


### PR DESCRIPTION
Closes #241, Closes #242

## Changes

### Issue #241 — Game Flow Clarity
- **Phase indicator** in HUD showing: 🌱 Planting → 💧 Tending → 🌾 Harvest → 🌙 Day End
- Current phase is **highlighted** with color; phase transitions have a brief flash animation
- **Contextual hints** appear when player has unused actions (e.g., 'Tap an empty tile to plant a seed')
- **Day advance summary** shows brief status on each new day ('Day 3 begins! • 4 plants growing • 1 ready to harvest')

### Issue #242 — Wire SeedInventory to Actual Run Seed Pool
- GardenScene now receives **SeedSelectionSystem** via constructor injection
- On init, reads **actual seed pool** from SeedSelectionSystem.getCurrentPool()
- Passes real pool to SeedInventory.setAvailableSeeds()
- **Removed hardcoded** ALL_PLANTS.filter() from SeedInventory constructor
- Seeds in inventory now **match exactly** what was shown in SeedSelectionScene

### Files Modified
- src/ui/HUD.ts — Phase indicator bar, contextual hint text, transition animation
- src/ui/SeedInventory.ts — Removed hardcoded seed initialization
- src/ui/index.ts — Export GamePhase type
- src/scenes/GardenScene.ts — Phase tracking, seed pool wiring, day advance summary
- src/main.ts — Pass SeedSelectionSystem to GardenScene

### Build
Zero TypeScript errors. Clean Vite production build.