### PR TITLE
docs: player-facing README (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,137 @@
-# 🌿 FLORA
+# 🌱 Flora — A Cozy Gardening Roguelite
 
 [![Deploy to GitHub Pages](https://github.com/jperezdelreal/flora/actions/workflows/deploy.yml/badge.svg)](https://github.com/jperezdelreal/flora/actions/workflows/deploy.yml)
 
-> Cozy gardening roguelite — procedural botanical art via L-systems
+Plant seeds, tend your garden, and survive seasonal challenges in a relaxing roguelite where every run grows new memories. Lose your garden each season, but keep what you discover.
 
-**Stack:** Vite + TypeScript + PixiJS v8
+**🎮 [Play Now](https://jperezdelreal.github.io/flora/)** — Play in your browser (no download needed!)
 
-**🎮 [Play Now](https://jperezdelreal.github.io/flora/)**
+---
 
-## Quick Start
+## How to Play
 
-```bash
-npm install
-npm run dev
-```
+### The Goal
+Survive one season of gardening! Plant seeds, water your crops, and harvest them to unlock new varieties. Each new plant you discover stays in your encyclopedia forever—even when your garden resets next season.
 
-Open http://localhost:3000
+### Controls
+| Action | Key |
+|--------|-----|
+| **Select/Plant** | Click on a garden tile |
+| **Water plant** | Click on a planted tile |
+| **Harvest plant** | Click on a mature plant (it glows!) |
+| **Remove pest** | Click on a plant with pests |
+| **Open Encyclopedia** | Press `E` (to see all plants you've discovered) |
+| **Open Achievements** | Press `A` (to track your progress) |
+| **Pause/Menu** | Press `Esc` |
+| **Keyboard shortcuts** | Arrow keys to navigate menus |
 
-## About
+### Gameplay Loop
 
-FLORA is a game by [First Frame Studios](https://github.com/jperezdelreal/FirstFrameStudios) — an AI-powered game development studio.
+**Phase 1: Plant Your Garden** (First 1-2 days)
+- Choose from a selection of random seeds
+- Click tiles to plant them strategically
+- Think about growth times, water needs, and seasonal challenges ahead
 
-Every run creates unique living botanical art through L-system fractals, watercolor gradients, and seasonal palettes.
+**Phase 2: Tend Your Garden** (Middle 8-10 days)
+- Each day, new things happen: plants grow, soil dries out, hazards appear
+- Click plants to water them
+- Click on pests when they appear to remove them
+- Watch plants mature and glow—they're ready to harvest!
+- Balance your time between watering, harvesting, and pest management
+
+**Phase 3: Harvest & Celebrate** (Last day)
+- Harvest your mature plants for seeds
+- New plants stay in your encyclopedia—unlock them forever
+- See your progress and start a new season with your new discoveries
+
+---
+
+## 🌿 Features
+
+✨ **22 Unique Plants to Discover**
+- Common varieties (Tomato, Lettuce, Carrot, Radish, Pea)
+- Uncommon herbs and vegetables (Sunflower, Mint, Pepper, Basil, Cucumber, Blueberry)
+- Rare treasures (Frost Willow, Lavender, Orchid, Venus Flytrap)
+- Heirloom heirlooms (Heirloom Squash, Golden Marigold, Ghost Pepper, Moonflower)
+
+🎨 **Procedurally Generated Plants**
+- Every plant looks unique and draws itself beautifully
+- Watch them grow through visible stages from seedling to full bloom
+- Colors shift with seasons: spring pastels, summer golds, fall russets, winter frosts
+
+📚 **Botanical Encyclopedia**
+- Unlock plants as you grow them
+- Track rarity levels (common, uncommon, rare, heirloom)
+- See how many you've discovered and what's still hidden
+- Beautiful card-based plant viewer with filtering and sorting
+
+🌍 **Dynamic Seasons**
+- Each run features a different season with unique challenges
+- Spring: Mild and forgiving
+- Summer: Heat stress and drought
+- Fall: Pest surges
+- Winter: Frost hazards and cold-resistant varieties
+
+🏆 **Gentle Progression**
+- Unlock new tools and seeds with each run
+- No time pressure—rest when you're overwhelmed
+- Failure is just "next season I'll try something different"
+- All challenges are solvable puzzles, never unfair punishments
+
+🎵 **Cozy Audioscape**
+- Relaxing ambient soundscapes (lo-fi gardening vibes)
+- Satisfying sound effects for every action
+- Seasonal music themes that evolve
+
+---
+
+## Plant Guide
+
+### Common Plants (Easy to Grow)
+- **Tomato** — Classic garden staple, needs daily water
+- **Lettuce** — Super fast to grow, fragile but rewarding
+- **Carrot** — Slow but drought-tough, low maintenance
+- **Radish** — Quick small crop for fast harvests
+- **Pea** — Spring legume, fixes nitrogen for neighbors
+
+### Uncommon Plants (Strategic)
+- **Sunflower** — Tall, takes time, yields lots of seeds
+- **Mint** — Fragrant herb that repels pests
+- **Pepper** — Heat-loving summer exclusive
+- **Basil** — Aromatic but inhibits some neighbors
+- **Cucumber** — Water-hungry vine that climbs
+- **Blueberry** — Fall exclusive with deep flavor
+
+### Rare Plants (Unlock & Cherish)
+- **Frost Willow** — Survives harsh winter conditions
+- **Lavender** — Drought legend, slow but legendary
+- **Orchid** — Exotic delicate beauty loves shade
+- **Venus Flytrap** — Eats pests but poisons neighbors
+
+### Heirloom Plants (Premium Discoveries)
+- **Heirloom Squash** — Long growth, abundant yield
+- **Golden Marigold** — Vibrant flowers, generous seeds
+- **Ghost Pepper** — Legendary heat, fierce deterrent
+- **Moonflower** — Mystical winter bloom opens under moonlight
+
+---
+
+## About Flora
+
+Flora is made by [First Frame Studios](https://github.com/jperezdelreal/FirstFrameStudios) — an AI-powered game development studio focused on cozy, soulful games.
+
+This is a game about patience, discovery, and the quiet joy of watching things grow. No timers. No harsh failures. Just you, a garden, and the seasons.
+
+For design details and inspiration, see the [Game Design Document](docs/GDD.md).
+
+---
+
+## Feedback & Support
+
+- 🐛 Found a bug? [Report it on GitHub](https://github.com/jperezdelreal/flora/issues)
+- 💭 Have suggestions? We'd love to hear from you!
+- 📖 Want to know more? Check out the [full GDD](docs/GDD.md) for the complete vision
+
+---
+
+**Ready to grow? [Play Now →](https://jperezdelreal.github.io/flora/)**


### PR DESCRIPTION
TLDR: Replaces dev README with player-facing documentation: how to play, features, plant guide. Closes #249.