### PR TITLE
feat: add keyboard shortcuts for tool selection (1-9 keys)

### DIFF
--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -83,6 +83,8 @@ export interface EventMap {
   // Tool progression events
   'tool:upgraded': { toolType: string; newTier: number; tierName: string };
   'tool:unlocked': { toolType: string; toolName: string };
+  // TLDR: Keyboard shortcut tool selection event for test hooks (#283)
+  'tool:selected': { toolType: string; toolName: string };
   // TLDR: Touch/responsive events
   'touch:tap': { x: number; y: number };
   'touch:longpress': { x: number; y: number };

--- a/src/scenes/GardenScene.ts
+++ b/src/scenes/GardenScene.ts
@@ -16,6 +16,7 @@ import { SynergySystem } from '../systems/SynergySystem';
 import { UnlockSystem } from '../systems/UnlockSystem';
 import { ToolSystem } from '../systems/ToolSystem';
 import type { ToolTier } from '../config/tools';
+import { TOOL_BY_TYPE } from '../config/tools';
 import { SaveManager } from '../systems/SaveManager';
 import { AnimationSystem, Easing } from '../systems/AnimationSystem';
 import { ParticleSystem } from '../systems/ParticleSystem';
@@ -718,6 +719,19 @@ export class GardenScene implements Scene {
   }
   
   private setupKeyboardShortcuts(): void {
+    // TLDR: Number-key → ToolType mapping for keyboard tool selection (#283)
+    const keyToolMap: Record<string, ToolType> = {
+      '1': ToolType.SEED,
+      '2': ToolType.WATER,
+      '3': ToolType.HARVEST,
+      '4': ToolType.REMOVE_PEST,
+      '5': ToolType.REMOVE_WEED,
+      '6': ToolType.COMPOST,
+      '7': ToolType.PEST_SPRAY,
+      '8': ToolType.SOIL_TESTER,
+      '9': ToolType.TRELLIS,
+    };
+
     // Store bound reference for proper cleanup
     this.boundOnKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -733,6 +747,21 @@ export class GardenScene implements Scene {
         if (!this.isPaused && !this.encyclopediaVisible) {
           this.seedInventory.toggle();
         }
+      } else if (keyToolMap[e.key] && !this.isPaused && !this.encyclopediaVisible) {
+        // TLDR: Number keys 1-9 select tools via keyboard (#283)
+        const toolType = keyToolMap[e.key];
+        const toolConfig = TOOL_BY_TYPE[toolType];
+
+        this.player.selectTool(toolType);
+        this.toolBar.setSelectedTool(toolType);
+
+        const displayName = toolConfig.displayName;
+        this.hud.setHint(`🔧 ${displayName} tool selected`);
+
+        eventBus.emit('tool:selected', {
+          toolType: toolType,
+          toolName: displayName,
+        });
       }
     };
     window.addEventListener('keydown', this.boundOnKeyDown);
@@ -2117,18 +2146,32 @@ export class GardenScene implements Scene {
 
   // ── Test hook getters (Playwright integration) ────────────────────────
 
+  /** TLDR: Select a tool by string name for Playwright test hooks (#284) */
+  public selectTestTool(tool: string): void {
+    this.player.selectTool(tool as ToolType);
+  }
+
   /** TLDR: Return player state snapshot for Playwright test hooks */
   public getTestPlayerState(): {
     day: number;
     actionsRemaining: number;
+    maxActions: number;
     selectedTool: string | null;
     gridPosition: { row: number; col: number };
+    row: number;
+    col: number;
+    isMoving: boolean;
   } {
+    const pos = this.player.getGridPosition();
     return {
       day: this.player.getCurrentDay(),
       actionsRemaining: this.player.getActionsRemaining(),
+      maxActions: this.player.getMaxActions(),
       selectedTool: this.player.getSelectedTool(),
-      gridPosition: this.player.getGridPosition(),
+      gridPosition: pos,
+      row: pos.row,
+      col: pos.col,
+      isMoving: this.player.isMoving(),
     };
   }
 

--- a/src/ui/ToolBar.ts
+++ b/src/ui/ToolBar.ts
@@ -13,6 +13,7 @@ export class ToolBar {
   private toolLockIcons: Map<ToolType, Text>;
   private toolTierTexts: Map<ToolType, Text>;
   private toolHintTexts: Map<ToolType, Text>;
+  private toolShortcutTexts: Map<ToolType, Text>;
   private selectedTool: ToolType | null = null;
   private unlockedTools: Set<ToolType> = new Set();
   private onToolSelect?: (tool: ToolType | null) => void;
@@ -26,6 +27,7 @@ export class ToolBar {
     this.toolLockIcons = new Map();
     this.toolTierTexts = new Map();
     this.toolHintTexts = new Map();
+    this.toolShortcutTexts = new Map();
     this.toolSystem = toolSystem;
 
     if (toolSystem) {
@@ -47,6 +49,19 @@ export class ToolBar {
     const buttonWidth = 80;
     const buttonHeight = 80;
     const padding = 10;
+
+    // TLDR: Keyboard shortcut key mapping — matches GardenScene keyToolMap (#283)
+    const toolShortcutKey: Record<string, string> = {
+      [ToolType.SEED]: '1',
+      [ToolType.WATER]: '2',
+      [ToolType.HARVEST]: '3',
+      [ToolType.REMOVE_PEST]: '4',
+      [ToolType.REMOVE_WEED]: '5',
+      [ToolType.COMPOST]: '6',
+      [ToolType.PEST_SPRAY]: '7',
+      [ToolType.SOIL_TESTER]: '8',
+      [ToolType.TRELLIS]: '9',
+    };
 
     ALL_TOOLS.forEach((tool, index) => {
       const buttonContainer = new Container();
@@ -172,6 +187,28 @@ export class ToolBar {
       hintText.visible = false;
       buttonContainer.addChild(hintText);
       this.toolHintTexts.set(tool.type, hintText);
+
+      // TLDR: Keyboard shortcut badge — top-left corner (#283)
+      const shortcutKey = toolShortcutKey[tool.type] ?? '';
+      if (shortcutKey) {
+        const shortcutBg = new Graphics();
+        shortcutBg.roundRect(0, 0, 16, 16, 3);
+        shortcutBg.fill({ color: UI_COLORS.PANEL_BG, alpha: 0.85 });
+        shortcutBg.stroke({ color: UI_COLORS.BUTTON_BORDER, width: 1 });
+        shortcutBg.x = 2;
+        shortcutBg.y = 2;
+        buttonContainer.addChild(shortcutBg);
+
+        const shortcutText = new Text({
+          text: shortcutKey,
+          style: { fontSize: 10, fill: UI_COLORS.TEXT_HINT, fontWeight: 'bold', align: 'center' },
+        });
+        shortcutText.anchor.set(0.5);
+        shortcutText.x = 10;
+        shortcutText.y = 10;
+        buttonContainer.addChild(shortcutText);
+        this.toolShortcutTexts.set(tool.type, shortcutText);
+      }
 
       buttonContainer.x = x;
       this.container.addChild(buttonContainer);
@@ -407,6 +444,7 @@ export class ToolBar {
     this.toolLockIcons.clear();
     this.toolTierTexts.clear();
     this.toolHintTexts.clear();
+    this.toolShortcutTexts.clear();
     this.unlockedTools.clear();
   }
 }


### PR DESCRIPTION
Closes #283

## Summary
Adds keyboard shortcuts (keys 1-9) for tool selection in the garden scene, plus shortcut number badges on toolbar buttons.

### Changes
- **GardenScene.ts**: Number keys 1-9 select tools (1=Seed, 2=Water, 3=Harvest, 4=Remove Pest, 5=Pull Weed, 6=Compost, 7=Pest Spray, 8=Soil Tester, 9=Trellis). Guarded by pause/encyclopedia state.
- **ToolBar.ts**: Small shortcut number badge (top-left corner) on each tool button using config colors.
- **EventBus.ts**: New \	ool:selected\ event for Playwright test hooks.

### Behavior
- Pressing a number key sets the player's tool, highlights the toolbar button, and shows a HUD hint (e.g. '🔧 Seed tool selected').
- Shortcuts are disabled when paused or encyclopedia is open.
- All colors use UI_COLORS constants. All comments TLDR.