### PR TITLE
feat(#288): Soil quality visuals

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -51,6 +51,12 @@ export const COLORS = {
   SKY_BLUE: 0x87ceeb,
   WHITE: 0xffffff,
   BLACK: 0x000000,
+  // Soil quality visual colors
+  SOIL_DEPLETED: 0xb8a88a,     // Grayish beige - depleted soil (<25%)
+  SOIL_RICH: 0x3d2817,         // Rich dark earth - high quality (>75%)
+  SOIL_QUALITY_GLOW: 0xfff9c4, // Warm sparkle for high-quality soil
+  PLANT_SOIL_GLOW: 0xa5d6a7,   // Subtle green glow behind plants on rich soil
+  COMPOST_PARTICLE: 0x5d4037,  // Compost particle color for animation
 } as const;
 
 /** TLDR: UI component color palette */

--- a/src/config/structures.ts
+++ b/src/config/structures.ts
@@ -94,5 +94,8 @@ export const GREENHOUSE_BONUS_DAYS = 2;
 /** TLDR: Soil quality boost applied by Compost Bin when a plant dies */
 export const COMPOST_SOIL_BOOST = 15;
 
+/** TLDR: Soil quality boost applied by the hand Compost tool per action */
+export const COMPOST_TOOL_BOOST = 15;
+
 /** TLDR: Number of adjacent tiles auto-watered by Rain Barrel each day */
 export const RAIN_BARREL_WATER_COUNT = 2;

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -1,6 +1,7 @@
 import { ToolType } from '../entities/Player';
 import { Tile, TileState } from '../entities/Tile';
 import { Plant } from '../entities/Plant';
+import { COMPOST_TOOL_BOOST } from './structures';
 
 export interface ToolConfig {
   type: ToolType;
@@ -227,11 +228,13 @@ export const TOOL_REMOVE_WEED: ToolConfig = {
 
 export const TOOL_COMPOST: ToolConfig = {
   type: ToolType.COMPOST, name: 'compost', displayName: 'Compost',
-  icon: '🪱', description: 'Apply compost to boost soil quality (+20%)',
+  icon: '🪱', description: `Apply compost to boost soil quality (+${COMPOST_TOOL_BOOST}%)`,
   validate: (tile: Tile, _plant: Plant | null): boolean => { return tile.soilQuality < 100; },
   execute: (tile: Tile, _plant: Plant | null): ToolActionResult => {
     if (tile.soilQuality >= 100) return { success: false, message: 'Soil quality is already at maximum' };
-    return { success: true, message: 'Applied compost! Soil quality boosted.', advanceDay: true };
+    const before = tile.soilQuality;
+    tile.setSoilQuality(tile.soilQuality + COMPOST_TOOL_BOOST);
+    return { success: true, message: `Applied compost! Soil: ${before}% → ${tile.soilQuality}%`, advanceDay: true };
   },
 };
 

--- a/src/scenes/GardenScene.ts
+++ b/src/scenes/GardenScene.ts
@@ -30,7 +30,7 @@ import { InputManager } from '../core/InputManager';
 import { TouchController } from '../core/TouchController';
 import { GAME, TOUCH, SCENES } from '../config';
 import { MenuScene } from './MenuScene';
-import { StructureType, STRUCTURE_CONFIGS, GREENHOUSE_BONUS_DAYS, COMPOST_SOIL_BOOST, RAIN_BARREL_WATER_COUNT } from '../config/structures';
+import { StructureType, STRUCTURE_CONFIGS, GREENHOUSE_BONUS_DAYS, COMPOST_SOIL_BOOST, COMPOST_TOOL_BOOST, RAIN_BARREL_WATER_COUNT } from '../config/structures';
 import { Season, SEASON_CONFIG, SEASON_ORDER, MULTI_SEASON_DAYS, MULTI_SEASON_SCORE_MULTIPLIER, getRandomSeason } from '../config/seasons';
 import { getSeasonalPalette, lerpColor } from '../config/seasonalPalettes';
 import { eventBus, type EventMap } from '../core/EventBus';
@@ -1007,6 +1007,22 @@ export class GardenScene implements Scene {
     if (result) {
       this.showActionMessage(result.message);
       this.gridSystem.update();
+
+      // TLDR: Compost tool visual feedback — particle animation + event
+      if (result.success && selectedTool === ToolType.COMPOST) {
+        const pos = this.player.getGridPosition();
+        const tile = this.grid.getTile(pos.row, pos.col);
+        if (tile) {
+          this.tileRenderer.playCompostAnimation(pos.row, pos.col);
+          this.tileRenderer.refreshTileAt(pos.row, pos.col);
+          eventBus.emit('compost:applied', {
+            row: pos.row,
+            col: pos.col,
+            soilQualityBefore: tile.soilQuality - COMPOST_TOOL_BOOST,
+            soilQualityAfter: tile.soilQuality,
+          });
+        }
+      }
     }
   }
 

--- a/src/systems/PlantRenderer.ts
+++ b/src/systems/PlantRenderer.ts
@@ -24,6 +24,13 @@ import {
 import { getSeasonalPalette, lerpColor, adjustSaturation } from '../config/seasonalPalettes';
 import type { System } from './index';
 
+// ─── Soil quality visual constants ────────────────────────────────────────
+const SOIL_QUALITY_HIGH_THRESHOLD = 75;
+const SOIL_QUALITY_LOW_THRESHOLD = 25;
+const SOIL_QUALITY_BRIGHTEN_FACTOR = 0.12;
+const SOIL_QUALITY_DULL_FACTOR = 0.18;
+const SOIL_QUALITY_LOW_DROOP_PX = 1.5;
+
 export interface PlantRendererConfig {
   animationSystem: AnimationSystem;
   plantSystem: PlantSystem;
@@ -36,8 +43,14 @@ function makeCacheKey(
   stage: GrowthStage,
   healthBucket: number,
   season: Season,
+  sqBucket: number,
 ): string {
-  return `${plantType}_${stage}_${healthBucket}_${season}`;
+  return `${plantType}_${stage}_${healthBucket}_${season}_sq${sqBucket}`;
+}
+
+/** Bucket soil quality into discrete levels for caching */
+function soilQualityBucket(quality: number): number {
+  return Math.floor(quality / 25) * 25;
 }
 
 export class PlantRenderer implements System {
@@ -48,9 +61,11 @@ export class PlantRenderer implements System {
   private swayPhases = new Map<string, number>();
   private plantBaseX = new Map<string, number>();
   private plantHealthCache = new Map<string, number>();
+  private plantSoilQualityCache = new Map<string, number>();
   private visualStateCache = new Map<string, string>();
   private synergyShimmerPhases = new Map<string, number>();
   private maturityGlows = new Map<string, Graphics>();
+  private soilQualityGlows = new Map<string, Graphics>();
   private currentSeason: Season = Season.SPRING;
 
   private animationSystem: AnimationSystem;
@@ -97,7 +112,9 @@ export class PlantRenderer implements System {
 
     const gfx = new Graphics();
     const configId = plant.getConfig().id;
-    this.drawPlantShape(gfx, configId, GrowthStage.SEED, plant.getHealth());
+    const tile = this.grid.getTile(row, col);
+    const sq = tile?.soilQuality ?? 50;
+    this.drawPlantShape(gfx, configId, GrowthStage.SEED, plant.getHealth(), sq);
     visual.addChild(gfx);
 
     this.plantVisualLayer.addChild(visual);
@@ -137,7 +154,9 @@ export class PlantRenderer implements System {
 
     const gfx = visual.children[0] as Graphics;
     if (gfx) {
-      this.drawPlantShape(gfx, configId, stage, plant.getHealth());
+      const tile = this.grid.getTile(plant.y, plant.x);
+      const sq = tile?.soilQuality ?? 50;
+      this.drawPlantShape(gfx, configId, stage, plant.getHealth(), sq);
     }
 
     const swayIntensity = visualDef?.swayIntensity ?? 1.0;
@@ -167,9 +186,11 @@ export class PlantRenderer implements System {
       this.swayPhases.delete(plantId);
       this.plantBaseX.delete(plantId);
       this.plantHealthCache.delete(plantId);
+      this.plantSoilQualityCache.delete(plantId);
       this.visualStateCache.delete(plantId);
       this.synergyShimmerPhases.delete(plantId);
       this.removeMaturityGlow(plantId);
+      this.removeSoilQualityGlow(plantId);
     }
   }
 
@@ -199,6 +220,29 @@ export class PlantRenderer implements System {
     }
   }
 
+  /** TLDR: Add a persistent green glow behind plants on high-quality soil (>75%) */
+  private addSoilQualityGlow(plantId: string): void {
+    if (this.soilQualityGlows.has(plantId)) return;
+    const visual = this.plantVisuals.get(plantId);
+    if (!visual) return;
+
+    const glow = new Graphics();
+    glow.circle(0, 0, ANIMATION.MATURE_GLOW_RADIUS * 0.9);
+    glow.fill({ color: COLORS.PLANT_SOIL_GLOW, alpha: 0.15 });
+    glow.alpha = 0.15;
+    visual.addChildAt(glow, 0);
+    this.soilQualityGlows.set(plantId, glow);
+  }
+
+  /** Remove soil quality glow graphic for a plant */
+  private removeSoilQualityGlow(plantId: string): void {
+    const glow = this.soilQualityGlows.get(plantId);
+    if (glow) {
+      glow.destroy();
+      this.soilQualityGlows.delete(plantId);
+    }
+  }
+
   /** Rebuild all plant visuals (after season change / restart) */
   rebuildAllVisuals(): void {
     for (const [, visual] of this.plantVisuals) {
@@ -208,9 +252,11 @@ export class PlantRenderer implements System {
     this.swayPhases.clear();
     this.plantBaseX.clear();
     this.plantHealthCache.clear();
+    this.plantSoilQualityCache.clear();
     this.visualStateCache.clear();
     this.synergyShimmerPhases.clear();
     this.maturityGlows.clear();
+    this.soilQualityGlows.clear();
 
     const activePlants = this.plantSystem.getActivePlants();
     for (const plant of activePlants) {
@@ -219,15 +265,17 @@ export class PlantRenderer implements System {
       if (visual) {
         const keyframe = getStageKeyframe(plant.getConfig().id, plant.getGrowthStage());
         visual.scale.set(keyframe.scale);
+        const tile = this.grid.getTile(plant.y, plant.x);
+        const sq = tile?.soilQuality ?? 50;
         const gfx = visual.children[0] as Graphics;
         if (gfx) {
-          this.drawPlantShape(gfx, plant.getConfig().id, plant.getGrowthStage(), plant.getHealth());
+          this.drawPlantShape(gfx, plant.getConfig().id, plant.getGrowthStage(), plant.getHealth(), sq);
         }
       }
     }
   }
 
-  /** Refresh a single plant's visual (for health changes / wilting) */
+  /** Refresh a single plant's visual (for health changes / wilting / soil quality) */
   refreshPlantVisual(plantId: string): void {
     const visual = this.plantVisuals.get(plantId);
     const plant = this.plantSystem.getPlant(plantId);
@@ -235,7 +283,9 @@ export class PlantRenderer implements System {
 
     const gfx = visual.children[0] as Graphics;
     if (gfx) {
-      this.drawPlantShape(gfx, plant.getConfig().id, plant.getGrowthStage(), plant.getHealth());
+      const tile = this.grid.getTile(plant.y, plant.x);
+      const sq = tile?.soilQuality ?? 50;
+      this.drawPlantShape(gfx, plant.getConfig().id, plant.getGrowthStage(), plant.getHealth(), sq);
     }
   }
 
@@ -290,7 +340,7 @@ export class PlantRenderer implements System {
 
   // ─── Per-Frame Update ────────────────────────────────────────────────
 
-  /** Per-frame visual update: idle sway, synergy shimmer, health refresh, orphan cleanup */
+  /** Per-frame visual update: idle sway, synergy shimmer, health refresh, soil quality, orphan cleanup */
   update(_delta: number): void {
     const time = performance.now() / 1000;
 
@@ -303,6 +353,29 @@ export class PlantRenderer implements System {
       const phase = this.swayPhases.get(plantId) ?? 0;
       const stage = plant.getGrowthStage();
       const isMatureOrGrowing = stage === GrowthStage.MATURE || stage === GrowthStage.GROWING;
+
+      // Soil quality tracking for visual refresh + glow management
+      const tile = this.grid.getTile(plant.y, plant.x);
+      const currentSoilQuality = tile?.soilQuality ?? 50;
+      const cachedSoilQuality = this.plantSoilQualityCache.get(plantId);
+      if (cachedSoilQuality === undefined || Math.abs(currentSoilQuality - cachedSoilQuality) > 10) {
+        this.plantSoilQualityCache.set(plantId, currentSoilQuality);
+        this.refreshPlantVisual(plantId);
+      }
+
+      // Soil quality glow management (>75% gets glow, ≤75% removes it)
+      if (currentSoilQuality > SOIL_QUALITY_HIGH_THRESHOLD && stage !== GrowthStage.SEED) {
+        this.addSoilQualityGlow(plantId);
+      } else {
+        this.removeSoilQualityGlow(plantId);
+      }
+
+      // Soil quality glow pulse
+      const soilGlow = this.soilQualityGlows.get(plantId);
+      if (soilGlow) {
+        const pulse = Math.sin(time * 1.5 + phase) * 0.5 + 0.5;
+        soilGlow.alpha = 0.1 + pulse * 0.1;
+      }
 
       // Idle sway: rotation on all non-seed stages
       if (stage !== GrowthStage.SEED) {
@@ -319,6 +392,15 @@ export class PlantRenderer implements System {
         const xSway = Math.sin(time * ANIMATION.SWAY_X_FREQUENCY * Math.PI * 2 + phase * 1.5) *
                        ANIMATION.SWAY_X_AMPLITUDE * swayIntensity;
         visual.x = baseX + xSway;
+      }
+
+      // Low soil quality droop: subtle downward y-offset on plants in depleted soil
+      if (currentSoilQuality < SOIL_QUALITY_LOW_THRESHOLD && stage !== GrowthStage.SEED) {
+        const droopIntensity = 1 - currentSoilQuality / SOIL_QUALITY_LOW_THRESHOLD;
+        const droopSway = Math.sin(time * 0.8 + phase) * droopIntensity * SOIL_QUALITY_LOW_DROOP_PX;
+        visual.pivot.y = -droopSway;
+      } else {
+        visual.pivot.y = 0;
       }
 
       // Mature pulse: subtle scale breathing to signal "harvest me"
@@ -349,7 +431,7 @@ export class PlantRenderer implements System {
           (ANIMATION.MATURE_GLOW_MAX_ALPHA - ANIMATION.MATURE_GLOW_MIN_ALPHA) * (pulse * 0.5 + 0.5);
       }
 
-      // Health-based visual refresh(only when health changes by >5%)
+      // Health-based visual refresh (only when health changes by >5%)
       const currentHealth = plant.getHealth();
       const cachedHealth = this.plantHealthCache.get(plantId);
       if (cachedHealth === undefined || Math.abs(currentHealth - cachedHealth) > 5) {
@@ -374,9 +456,11 @@ export class PlantRenderer implements System {
     this.swayPhases.clear();
     this.plantBaseX.clear();
     this.plantHealthCache.clear();
+    this.plantSoilQualityCache.clear();
     this.visualStateCache.clear();
     this.synergyShimmerPhases.clear();
     this.maturityGlows.clear();
+    this.soilQualityGlows.clear();
     this.plantVisualLayer.destroy({ children: true });
   }
 
@@ -385,11 +469,13 @@ export class PlantRenderer implements System {
   /**
    * Draw plant shape per growth stage — unique visual identity per plant.
    * Uses cache key to skip redundant redraws.
+   * Soil quality adjusts color brightness: high = brighter, low = duller.
    */
-  private drawPlantShape(gfx: Graphics, plantId: string, stage: GrowthStage, health: number): void {
+  private drawPlantShape(gfx: Graphics, plantId: string, stage: GrowthStage, health: number, soilQuality: number = 50): void {
     // Check cache to avoid redundant redraws
     const healthBucket = Math.floor(health / 10) * 10;
-    const cacheKey = makeCacheKey(plantId, stage, healthBucket, this.currentSeason);
+    const sqBucket = soilQualityBucket(soilQuality);
+    const cacheKey = makeCacheKey(plantId, stage, healthBucket, this.currentSeason, sqBucket);
     const existingKey = this.visualStateCache.get(plantId);
     if (existingKey === cacheKey) return;
     this.visualStateCache.set(plantId, cacheKey);
@@ -431,6 +517,11 @@ export class PlantRenderer implements System {
     const accColor = adjustColorForHealth(accentColor, health);
     const detColor = adjustColorForHealth(detailColor, health);
 
+    // TLDR: Soil quality tint — brighten on rich soil, dull on depleted soil
+    const adjustedMainColor = this.adjustColorForSoilQuality(mainColor, soilQuality);
+    const adjustedAccColor = this.adjustColorForSoilQuality(accColor, soilQuality);
+    const adjustedDetColor = this.adjustColorForSoilQuality(detColor, soilQuality);
+
     const alpha = keyframe.alpha * (health > 50 ? 1.0 : 0.7);
 
     // Harvest-ready glow on ALL mature plants; stronger glow for glowOnMature species
@@ -438,26 +529,42 @@ export class PlantRenderer implements System {
       const glowAlpha = visualDef.glowOnMature ? 0.4 : 0.2;
       const glowRadius = shapeData.mainRadius + (visualDef.glowOnMature ? 6 : 4);
       gfx.circle(0, keyframe.yOffset, glowRadius);
-      gfx.fill({ color: accColor, alpha: glowAlpha });
+      gfx.fill({ color: adjustedAccColor, alpha: glowAlpha });
     }
 
     switch (stage) {
       case GrowthStage.SEED:
-        this.drawSeedShape(gfx, visualDef, shapeData, mainColor, accColor, alpha);
+        this.drawSeedShape(gfx, visualDef, shapeData, adjustedMainColor, adjustedAccColor, alpha);
         break;
       case GrowthStage.SPROUT:
-        this.drawSproutShape(gfx, visualDef, shapeData, mainColor, accColor, detColor, alpha, keyframe.yOffset);
+        this.drawSproutShape(gfx, visualDef, shapeData, adjustedMainColor, adjustedAccColor, adjustedDetColor, alpha, keyframe.yOffset);
         break;
       case GrowthStage.GROWING:
-        this.drawGrowingShape(gfx, visualDef, shapeData, mainColor, accColor, detColor, alpha, keyframe.yOffset);
+        this.drawGrowingShape(gfx, visualDef, shapeData, adjustedMainColor, adjustedAccColor, adjustedDetColor, alpha, keyframe.yOffset);
         break;
       case GrowthStage.MATURE:
-        this.drawMatureShape(gfx, visualDef, shapeData, mainColor, accColor, detColor, alpha, keyframe.yOffset);
+        this.drawMatureShape(gfx, visualDef, shapeData, adjustedMainColor, adjustedAccColor, adjustedDetColor, alpha, keyframe.yOffset);
         break;
       case GrowthStage.WILTING:
-        this.drawWiltingShape(gfx, visualDef, shapeData, mainColor, accColor, detColor, alpha, keyframe.yOffset);
+        this.drawWiltingShape(gfx, visualDef, shapeData, adjustedMainColor, adjustedAccColor, adjustedDetColor, alpha, keyframe.yOffset);
         break;
     }
+  }
+
+  /**
+   * TLDR: Adjust a plant color based on soil quality.
+   * High quality (>75%) brightens toward lighter green; low quality (<25%) desaturates toward gray.
+   */
+  private adjustColorForSoilQuality(color: number, soilQuality: number): number {
+    if (soilQuality > SOIL_QUALITY_HIGH_THRESHOLD) {
+      const t = (soilQuality - SOIL_QUALITY_HIGH_THRESHOLD) / (100 - SOIL_QUALITY_HIGH_THRESHOLD);
+      return lerpColor(color, COLORS.PLANT_SOIL_GLOW, t * SOIL_QUALITY_BRIGHTEN_FACTOR);
+    }
+    if (soilQuality < SOIL_QUALITY_LOW_THRESHOLD) {
+      const t = 1 - soilQuality / SOIL_QUALITY_LOW_THRESHOLD;
+      return lerpColor(color, 0x808080, t * SOIL_QUALITY_DULL_FACTOR);
+    }
+    return color;
   }
 
   private drawFallbackShape(gfx: Graphics, stage: GrowthStage): void {

--- a/src/systems/TileRenderer.ts
+++ b/src/systems/TileRenderer.ts
@@ -13,6 +13,7 @@ import { StructureType } from '../config/structures';
 import { Season } from '../config/seasons';
 import { getSeasonalPalette, lerpColor, adjustSaturation } from '../config/seasonalPalettes';
 import { getActivePalette } from '../utils/accessibility';
+import { COLORS } from '../config';
 import type { System } from './index';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -37,7 +38,8 @@ type RenderableStructure = StructureType | 'trellis';
 const SOIL_COLORS = {
   dry: 0xc4a882,       // Light brown — dry soil
   moist: 0x5c3a1e,     // Dark brown — moist soil
-  richEarth: 0x3d2817, // Rich dark earth — high quality
+  richEarth: COLORS.SOIL_RICH,  // Rich dark earth — high quality
+  depleted: COLORS.SOIL_DEPLETED, // Grayish beige — depleted soil
 } as const;
 
 /** Overlay colors for tile states */
@@ -97,6 +99,18 @@ function makeTileCacheKey(state: TileVisualState, structureType?: RenderableStru
   return structureType ? `${base}_${structureType}` : base;
 }
 
+// ─── Compost animation types ────────────────────────────────────────────────
+
+interface CompostParticle {
+  gfx: Graphics;
+  x: number;
+  y: number;
+  vy: number;
+  alpha: number;
+  life: number;
+  maxLife: number;
+}
+
 // ─── TileRenderer ───────────────────────────────────────────────────────────
 
 export class TileRenderer implements System {
@@ -114,6 +128,9 @@ export class TileRenderer implements System {
 
   /** TLDR: Dirty tracking — only re-render tiles that changed this frame */
   private dirtyTiles = new Set<Tile>();
+
+  /** TLDR: Active compost particle animations */
+  private compostParticles: CompostParticle[] = [];
 
   constructor(config: TileRendererConfig) {
     this.grid = config.grid;
@@ -197,9 +214,14 @@ export class TileRenderer implements System {
       }
     }
     this.dirtyTiles.clear();
+
+    // TLDR: Tick compost particle animations
+    this.updateCompostParticles();
   }
 
   destroy(): void {
+    for (const p of this.compostParticles) p.gfx.destroy();
+    this.compostParticles = [];
     this.tileLayer.destroy({ children: true });
     this.tileGraphics.clear();
     this.visualStateCache.clear();
@@ -264,9 +286,14 @@ export class TileRenderer implements System {
       this.drawPestOverlay(gfx, size, padding);
     }
 
-    // High-quality soil sparkle (quality ≥ 80)
-    if (tile.soilQuality >= 80 && tile.state !== TileState.STRUCTURE) {
+    // High-quality soil sparkle (quality ≥ 75)
+    if (tile.soilQuality >= 75 && tile.state !== TileState.STRUCTURE) {
       this.drawQualityIndicator(gfx, size, padding, tile.soilQuality);
+    }
+
+    // Low-quality soil depleted cracks (quality < 25)
+    if (tile.soilQuality < 25 && tile.state !== TileState.STRUCTURE) {
+      this.drawDepletedIndicator(gfx, size, padding, tile.soilQuality);
     }
   }
 
@@ -275,7 +302,7 @@ export class TileRenderer implements System {
   /**
    * Compute soil color based on moisture and quality.
    * Moisture controls darkness: dry = light brown, moist = dark brown.
-   * Quality adds richness: high quality = darker, richer earth.
+   * Quality shifts the palette: low = depleted gray, high = rich dark earth.
    * Seasonal palette shifts the base color.
    */
   private computeSoilColor(moisture: number, quality: number): number {
@@ -286,10 +313,17 @@ export class TileRenderer implements System {
     const moistureT = Math.min(1, Math.max(0, moisture / 100));
     let baseColor = lerpColor(SOIL_COLORS.dry, SOIL_COLORS.moist, moistureT);
 
-    // Quality enrichment: blend toward rich earth for high quality
     const qualityT = Math.min(1, Math.max(0, quality / 100));
+
+    // Low quality: blend toward depleted grayish tint
+    if (qualityT < 0.25) {
+      const depletedT = 1 - qualityT / 0.25;
+      baseColor = lerpColor(baseColor, SOIL_COLORS.depleted, depletedT * 0.35);
+    }
+
+    // High quality: blend toward rich earth
     if (qualityT > 0.6) {
-      const richT = (qualityT - 0.6) / 0.4; // 0-1 range for quality 60-100
+      const richT = (qualityT - 0.6) / 0.4;
       baseColor = lerpColor(baseColor, SOIL_COLORS.richEarth, richT * 0.4);
     }
 
@@ -361,21 +395,93 @@ export class TileRenderer implements System {
     gfx.fill({ color: palette.danger, alpha: 0.8 });
   }
 
-  /** Subtle sparkle dots for high-quality soil */
+  /** Subtle sparkle dots for high-quality soil (≥75%) */
   private drawQualityIndicator(gfx: Graphics, size: number, padding: number, quality: number): void {
-    const intensity = (quality - 80) / 20; // 0-1 for quality 80-100
+    const intensity = (quality - 75) / 25; // 0-1 for quality 75-100
     const count = Math.floor(2 + intensity * 3);
     const inner = padding * 2 + 4;
     const range = size - inner * 2;
 
-    // Deterministic sparkle positions based on size
     for (let i = 0; i < count; i++) {
       const t = (i + 0.5) / count;
       const sx = inner + (t * 0.7 + 0.15) * range;
       const sy = inner + ((t * 1.3 + 0.3) % 1) * range;
 
       gfx.circle(sx, sy, 1.5);
-      gfx.fill({ color: 0xfff9c4, alpha: 0.3 + intensity * 0.3 });
+      gfx.fill({ color: COLORS.SOIL_QUALITY_GLOW, alpha: 0.3 + intensity * 0.3 });
+    }
+  }
+
+  /** Subtle crack lines on depleted soil (<25%) */
+  private drawDepletedIndicator(gfx: Graphics, size: number, padding: number, quality: number): void {
+    const intensity = 1 - quality / 25; // 1 at 0%, 0 at 25%
+    const inner = padding * 2 + 6;
+    const range = size - inner * 2;
+
+    const crackCount = Math.floor(1 + intensity * 2);
+    for (let i = 0; i < crackCount; i++) {
+      const t = (i + 0.5) / (crackCount + 1);
+      const x1 = inner + t * range * 0.3;
+      const y1 = inner + t * range;
+      const x2 = inner + t * range * 0.7 + range * 0.2;
+      const y2 = inner + t * range * 0.5;
+
+      gfx.moveTo(x1, y1);
+      gfx.lineTo((x1 + x2) / 2, (y1 + y2) / 2 + 2);
+      gfx.lineTo(x2, y2);
+      gfx.stroke({ color: SOIL_COLORS.depleted, width: 0.8, alpha: 0.2 + intensity * 0.2 });
+    }
+  }
+
+  // ─── Compost animation ────────────────────────────────────────────────
+
+  /** TLDR: Spawn compost particles that rise and absorb into the tile */
+  playCompostAnimation(row: number, col: number): void {
+    const pos = this.grid.getTilePosition(row, col);
+    const size = this.grid.config.tileSize;
+    const cx = pos.x + size / 2;
+    const cy = pos.y + size / 2;
+
+    for (let i = 0; i < 8; i++) {
+      const gfx = new Graphics();
+      const particleX = cx + (Math.random() - 0.5) * size * 0.6;
+      const particleY = cy + size * 0.3;
+      const particleSize = 1.5 + Math.random() * 2;
+
+      gfx.circle(0, 0, particleSize);
+      gfx.fill({ color: COLORS.COMPOST_PARTICLE, alpha: 0.8 });
+      gfx.x = particleX;
+      gfx.y = particleY;
+      this.tileLayer.addChild(gfx);
+
+      this.compostParticles.push({
+        gfx,
+        x: particleX,
+        y: particleY,
+        vy: -(0.5 + Math.random() * 1.0),
+        alpha: 0.8,
+        life: 0,
+        maxLife: 40 + Math.random() * 20,
+      });
+    }
+  }
+
+  /** TLDR: Update compost particles — rise, sway, fade, then destroy */
+  private updateCompostParticles(): void {
+    for (let i = this.compostParticles.length - 1; i >= 0; i--) {
+      const p = this.compostParticles[i];
+      p.life++;
+      p.y += p.vy;
+      p.vy *= 0.97;
+      p.alpha = 0.8 * (1 - p.life / p.maxLife);
+      p.gfx.x = p.x + Math.sin(p.life * 0.2) * 2;
+      p.gfx.y = p.y;
+      p.gfx.alpha = p.alpha;
+
+      if (p.life >= p.maxLife) {
+        p.gfx.destroy();
+        this.compostParticles.splice(i, 1);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Closes #288 - Makes soil quality progression visible to players.

### Changes
**COMPOST Tool Fix:** Now applies +15% soil quality (was no-op). Emits compost:applied event.

**Tile Visuals:** Depleted soil (<25%) gray tint + cracks. Rich soil (>75%) sparkle. Full gradient.

**Compost Animation:** 8 particles rise and fade on tool use.

**Plant Tinting:** Rich soil brightens colors + green glow. Depleted soil dulls + droop animation.

**Config:** COMPOST_TOOL_BOOST=15, 5 new COLORS entries for soil visuals.

### Acceptance Criteria
- [x] Plants on high soil (>75%) brighter + glow
- [x] Plants on low soil (<25%) duller + droop
- [x] Compost tool raises soil by 15
- [x] Compost particles animated
- [x] Tile background color shift
- [x] Non-intrusive cozy feel

Build: Zero TS errors. Clean Vite build.