### PR TITLE
feat: harvest E2E test (#305) + movement SFX (#306)

### DIFF
--- a/src/config/audio.ts
+++ b/src/config/audio.ts
@@ -81,6 +81,12 @@ export const AUDIO = {
       chimeDuration: 0.2,
       chimeStagger: 0.1,
     },
+    MOVE: {
+      type: 'move' as const,
+      duration: 0.12,
+      frequency: 220,
+      noiseFilterFreq: 600,
+    },
   },
 } as const;
 

--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -20,6 +20,7 @@ export interface EventMap {
   // Player action events
   'action:consumed': { actionsRemaining: number; maxActions: number };
   'player:rested': { soilBoost: number; day: number };
+  'player:moved': { fromRow: number; fromCol: number; toRow: number; toCol: number };
   // Day/season events
   'day:advanced': { day: number };
   'season:ended': { season: string; day: number };

--- a/src/systems/AudioManager.ts
+++ b/src/systems/AudioManager.ts
@@ -69,6 +69,7 @@ export class AudioManager {
   private boundToolUpgraded!: () => void;
   private boundToolUnlocked!: () => void;
   private boundPlantMatured!: () => void;
+  private boundPlayerMoved!: () => void;
   
   /**
    * Initialize audio context and routing graph
@@ -148,6 +149,10 @@ export class AudioManager {
     
     this.boundPlantMatured = () => this.playSFX('MATURE');
     eventBus.on('plant:matured', this.boundPlantMatured);
+
+    // Player movement event
+    this.boundPlayerMoved = () => this.playSFX('MOVE');
+    eventBus.on('player:moved', this.boundPlayerMoved);
   }
   
   /**
@@ -314,6 +319,9 @@ export class AudioManager {
       case 'MATURE':
         this._playMatureSFX(now);
         break;
+      case 'MOVE':
+        this._playMoveSFX(now);
+        break;
     }
   }
   
@@ -464,6 +472,7 @@ export class AudioManager {
     eventBus.off('tool:upgraded', this.boundToolUpgraded);
     eventBus.off('tool:unlocked', this.boundToolUnlocked);
     eventBus.off('plant:matured', this.boundPlantMatured);
+    eventBus.off('player:moved', this.boundPlayerMoved);
     
     this.stopAmbient();
     
@@ -619,6 +628,36 @@ export class AudioManager {
       chimeOsc.start(chimeStart);
       chimeOsc.stop(chimeStart + config.chimeDuration);
     }
+  }
+  
+  /**
+   * TLDR: Subtle footstep sound for tile movement — soft filtered noise tap (#306)
+   */
+  private _playMoveSFX(startTime: number): void {
+    if (!this.ctx || !this.sfxBus) return;
+    
+    const config = AUDIO.SFX.MOVE;
+    
+    // Soft noise tap (grass crunch)
+    const noise = this._createNoiseBuffer();
+    const noiseSource = this.ctx.createBufferSource();
+    noiseSource.buffer = noise;
+    
+    const filter = this.ctx.createBiquadFilter();
+    filter.type = 'lowpass';
+    filter.frequency.value = config.noiseFilterFreq;
+    filter.Q.value = 1;
+    
+    const gain = this.ctx.createGain();
+    // Volume at 40% of action layer (subtle, not distracting)
+    gain.gain.setValueAtTime(0.12, startTime);
+    gain.gain.exponentialRampToValueAtTime(0.01, startTime + config.duration);
+    
+    noiseSource.connect(filter);
+    filter.connect(gain);
+    gain.connect(this.sfxBus);
+    noiseSource.start(startTime);
+    noiseSource.stop(startTime + config.duration);
   }
   
   private _playWiltSFX(startTime: number): void {

--- a/src/systems/PlayerSystem.ts
+++ b/src/systems/PlayerSystem.ts
@@ -123,9 +123,20 @@ export class PlayerSystem implements System {
     this.targetX = targetWorldPos.x + this.grid.config.tileSize / 2;
     this.targetY = targetWorldPos.y + this.grid.config.tileSize / 2;
 
+    // TLDR: Emit movement event for SFX before position update (#306)
+    const fromRow = currentPos.row;
+    const fromCol = currentPos.col;
+
     // Movement is free — only tool use costs actions
     this.player.moveTo(targetRow, targetCol);
     this.moveAnimationT = 0;
+
+    eventBus.emit('player:moved', {
+      fromRow,
+      fromCol,
+      toRow: targetRow,
+      toCol: targetCol,
+    });
   }
 
   private updateMovementAnimation(deltaTime: number): void {

--- a/src/utils/testHooks.ts
+++ b/src/utils/testHooks.ts
@@ -21,6 +21,7 @@ const TRACKED_EVENTS: Array<keyof EventMap> = [
   'pest:spawned',
   'pest:removed',
   'action:consumed',
+  'player:moved',
 ];
 
 export interface FloraTestHooks {

--- a/tests/e2e/flora-gameplay.spec.ts
+++ b/tests/e2e/flora-gameplay.spec.ts
@@ -609,4 +609,111 @@ test.describe('Flora Real Gameplay E2E Tests', () => {
 
     console.log(`🎮 Multi-day run complete! Days: ${DAYS_TO_PLAY}, Final day: ${finalState.day}, Plants: ${finalPlantCount}, Active: ${activePlants.length}`);
   });
+
+  test('Full harvest cycle: plant → water → mature → harvest (#305)', async ({ page }) => {
+    test.setTimeout(180000); // 3 min — needs multiple day advances
+
+    // 1. Get to garden
+    await getToGarden(page);
+
+    const initialState = await getPlayerState(page);
+    expect(initialState.day).toBe(1);
+    expect(initialState.actionsRemaining).toBe(3);
+
+    const initialPlantCount = await page.evaluate(() => window.__FLORA__!.getPlantCount());
+    expect(initialPlantCount).toBe(0);
+
+    // 2. Plant a seed at tile (0,0)
+    await page.evaluate(([r, c]) => window.__FLORA__!.movePlayer(r, c), [0, 0] as [number, number]);
+    await waitFrames(page, 5);
+
+    await page.evaluate(() => window.__FLORA__!.selectTool('seed'));
+    await clearEvents(page);
+    const plantResult = await page.evaluate(() => window.__FLORA__!.performAction());
+    expect(plantResult.success, 'Planting should succeed: ' + plantResult.message).toBe(true);
+    await waitFrames(page, 10);
+
+    const eventsAfterPlant = await getEvents(page);
+    expect(eventsAfterPlant.some((e) => e.includes('plant:created')),
+      'plant:created event must fire after planting').toBe(true);
+
+    const plantCountAfterPlant = await page.evaluate(() => window.__FLORA__!.getPlantCount());
+    expect(plantCountAfterPlant).toBe(1);
+
+    // 3. Water the planted seed
+    await page.evaluate(([r, c]) => window.__FLORA__!.movePlayer(r, c), [0, 0] as [number, number]);
+    await waitFrames(page, 5);
+    await page.evaluate(() => window.__FLORA__!.selectTool('water'));
+    const waterResult = await page.evaluate(() => window.__FLORA__!.performAction());
+    expect(waterResult.success, 'Watering should succeed: ' + waterResult.message).toBe(true);
+    await waitFrames(page, 10);
+
+    // 4. Rest repeatedly to advance days until plant matures
+    const MAX_REST_CYCLES = 20;
+    let mature = false;
+
+    for (let i = 0; i < MAX_REST_CYCLES; i++) {
+      // Rest to advance to next day
+      const rested = await page.evaluate(() => window.__FLORA__!.rest());
+      expect(rested, `Rest cycle ${i + 1} should succeed`).toBe(true);
+      await waitFrames(page, 30);
+
+      // Wait for day to actually advance
+      await waitFrames(page, 30);
+
+      // Water the plant again each day to keep it healthy
+      await page.evaluate(([r, c]) => window.__FLORA__!.movePlayer(r, c), [0, 0] as [number, number]);
+      await waitFrames(page, 5);
+      await page.evaluate(() => window.__FLORA__!.selectTool('water'));
+      const dayWater = await page.evaluate(() => window.__FLORA__!.performAction());
+      if (dayWater.success) {
+        await waitFrames(page, 5);
+      }
+
+      // Check if any plant has reached mature stage
+      const plants = await page.evaluate(() => window.__FLORA__!.getActivePlants());
+      const maturePlant = plants.find((p: { growthStage: string }) => p.growthStage === 'mature');
+      if (maturePlant) {
+        mature = true;
+        console.log(`🌱 Plant matured after ${i + 1} rest cycles (day ${(await getPlayerState(page)).day})`);
+        break;
+      }
+    }
+
+    expect(mature, 'Plant should reach mature stage within ' + MAX_REST_CYCLES + ' days').toBe(true);
+
+    // 5. Harvest the mature plant
+    const plantCountBeforeHarvest = await page.evaluate(() => window.__FLORA__!.getPlantCount());
+    const stateBeforeHarvest = await getPlayerState(page);
+
+    await page.evaluate(([r, c]) => window.__FLORA__!.movePlayer(r, c), [0, 0] as [number, number]);
+    await waitFrames(page, 5);
+    await page.evaluate(() => window.__FLORA__!.selectTool('harvest'));
+    await clearEvents(page);
+
+    const harvestResult = await page.evaluate(() => window.__FLORA__!.performAction());
+    expect(harvestResult.success, 'Harvesting mature plant should succeed: ' + harvestResult.message).toBe(true);
+    await waitFrames(page, 10);
+
+    // 6. ASSERT: plant:harvested event fired
+    const eventsAfterHarvest = await getEvents(page);
+    expect(eventsAfterHarvest.some((e) => e.includes('plant:harvested')),
+      'plant:harvested event must fire after harvesting').toBe(true);
+
+    // ASSERT: plant count decreased
+    const plantCountAfterHarvest = await page.evaluate(() => window.__FLORA__!.getPlantCount());
+    expect(plantCountAfterHarvest).toBeLessThan(plantCountBeforeHarvest);
+
+    // ASSERT: actions decreased
+    const stateAfterHarvest = await getPlayerState(page);
+    expect(stateAfterHarvest.actionsRemaining).toBeLessThan(stateBeforeHarvest.actionsRemaining);
+
+    // ASSERT: action:consumed event also fired
+    expect(eventsAfterHarvest.some((e) => e.includes('action:consumed')),
+      'action:consumed event must fire after harvest action').toBe(true);
+
+    console.log('✅ Full harvest cycle verified: plant → water → mature → harvest');
+    console.log(`   Plants: ${plantCountBeforeHarvest} → ${plantCountAfterHarvest}`);
+    console.log(`   Actions: ${stateBeforeHarvest.actionsRemaining} → ${stateAfterHarvest.actionsRemaining}`);
+  });
 });


### PR DESCRIPTION
## Changes

### #305 — Harvest E2E Test (P1)
- **New test**: \Full harvest cycle: plant → water → mature → harvest\ in \lora-gameplay.spec.ts\
- Uses test hooks: \selectTool\, \movePlayer\, \performAction\, \est\
- Plants seed, waters it, rests until \getActivePlants()\ shows \growthStage === 'mature'\
- Harvests and asserts: \plant:harvested\ event fired, \plantCount\ decreased, \ctionsRemaining\ decreased

### #306 — Movement SFX (P2)
- **EventBus**: Added \player:moved\ event with \romRow/fromCol/toRow/toCol\ payload
- **PlayerSystem**: Emits \player:moved\ in \startMove()\ on each tile transition
- **AudioManager**: Subscribes to \player:moved\, plays procedural footstep SFX
- **MOVE SFX**: Soft low-pass filtered noise tap (~0.12s, 0.12 gain = 40% of action layer)
- **Debounced**: Uses existing 50ms per-type debounce (no stacking)
- **Cleanup**: Bound listener removed in \destroy()\
- **testHooks**: \player:moved\ tracked for Playwright assertions

### Files Changed (6)
| File | Change |
|------|--------|
| \src/core/EventBus.ts\ | Add \player:moved\ event type |
| \src/config/audio.ts\ | Add \MOVE\ SFX config |
| \src/systems/PlayerSystem.ts\ | Emit \player:moved\ on tile transition |
| \src/systems/AudioManager.ts\ | Subscribe + play MOVE SFX |
| \src/utils/testHooks.ts\ | Track \player:moved\ event |
| \	ests/e2e/flora-gameplay.spec.ts\ | Add harvest cycle test |

### Build
Zero TypeScript errors. Clean Vite production build.

Closes #305, closes #306